### PR TITLE
Makes Given-When-Then more prominent in TOC and primer document flow

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -32,7 +32,8 @@
     * [Dynamic Suites](primers/testbox-bdd-primer/suites-describe-your-tests/dynamic-suites.md)
   * [Specs](primers/testbox-bdd-primer/specs.md)
   * [Expectations](primers/testbox-bdd-primer/expectations.md)
-  * [Suite Groups](primers/testbox-bdd-primer/suite-groups.md)
+  * [Suite Groups](primers/testbox-bdd-primer/suite-groups/README.md)
+    * [Given-When-Then Blocks](primers/testbox-bdd-primer/suite-groups/given-when-then-blocks.md)
   * [Life-Cycle Methods](primers/testbox-bdd-primer/life-cycle-methods.md)
   * [Specs and Suite Labels](primers/testbox-bdd-primer/specs-and-suite-labels.md)
   * [Skipping Specs and Suites](primers/testbox-bdd-primer/skipping-specs-and-suites.md)
@@ -128,4 +129,3 @@
 * [Gitlab](continuous-integration/gitlab.md)
 * [Travis](continuous-integration/travis.md)
 * [Jenkins](continuous-integration/jenkins.md)
-

--- a/primers/testbox-bdd-primer/suite-groups/README.md
+++ b/primers/testbox-bdd-primer/suite-groups/README.md
@@ -1,0 +1,70 @@
+# Suite Groups
+
+As we have seen before, the `describe()` function describes a test suite of related specs in a test bundle CFC. The title of the suite is concatenated with the title of a spec to create a full spec's name which is very descriptive. If you name them well, they will read out as full sentences as defined by [BDD](http://en.wikipedia.org/wiki/Behavior-driven_development) style.
+
+```javascript
+describe("A spec", function() {
+     it("is just a closure, so it can contain any code", function() {
+          coldbox = 0;
+          coldbox++;
+
+          expect( coldbox ).toBe( 1 );
+     });
+
+     it("can have more than one expectation", function() {
+          coldbox = 0;
+          coldbox++;
+
+          expect( coldbox ).toBe( 1 );
+          expect( coldbox ).toBeTrue();
+     });
+});
+```
+
+## Nesting describe Blocks
+
+Calls to our `describe()` function can be nested with specs at any level or point of execution. This allows you to create your tests as a related tree of nested functions. Please note that before a spec is executed, TestBox walks down the tree executing each `beforeEach()` and `afterEach()` function in the declared order. This is a great way to logically group specs in any level as you see fit.
+
+```javascript
+describe("A spec", function() {
+
+     beforeEach(function( currentSpec ) {
+          coldbox = 22;
+          application.wirebox = new coldbox.system.ioc.Injector();
+     });
+
+     afterEach(function( currentSpec ) {
+          coldbox = 0;
+          structDelete( application, "wirebox" );
+     });
+
+     it("is just a function, so it can contain any code", function() {
+          expect( coldbox ).toBe( 22 );
+     });
+
+     it("can have more than one expectation and talk to scopes", function() {
+          expect( coldbox ).toBe( 22 );
+          expect( application.wirebox.getInstance( 'MyService' ) ).toBeComponent();
+     });
+
+     describe("nested inside a second describe", function() {
+
+          beforeEach(function( currentSpec ) {
+               awesome = 22;
+          });
+
+          afterEach(function( currentSpec ) {
+               awesome = 22 + 8;
+          });
+
+          it("can reference both scopes as needed ", function() {
+            expect( coldbox ).toBe( awesome );
+          });
+     });
+
+     it("can be declared after nested suites and have access to nested variables", function() {
+          expect( awesome ).toBe( 30 );
+     });
+
+});
+```

--- a/primers/testbox-bdd-primer/suite-groups/given-when-then-blocks.md
+++ b/primers/testbox-bdd-primer/suite-groups/given-when-then-blocks.md
@@ -1,75 +1,4 @@
-# Suite Groups
-
-As we have seen before, the `describe()` function describes a test suite of related specs in a test bundle CFC. The title of the suite is concatenated with the title of a spec to create a full spec's name which is very descriptive. If you name them well, they will read out as full sentences as defined by [BDD](http://en.wikipedia.org/wiki/Behavior-driven_development) style.
-
-```javascript
-describe("A spec", function() {
-     it("is just a closure, so it can contain any code", function() {
-          coldbox = 0;
-          coldbox++;
-
-          expect( coldbox ).toBe( 1 );
-     });
-
-     it("can have more than one expectation", function() {
-          coldbox = 0;
-          coldbox++;
-
-          expect( coldbox ).toBe( 1 );
-          expect( coldbox ).toBeTrue();
-     });
-});
-```
-
-## Nesting describe Blocks
-
-Calls to our `describe()` function can be nested with specs at any level or point of execution. This allows you to create your tests as a related tree of nested functions. Please note that before a spec is executed, TestBox walks down the tree executing each `beforeEach()` and `afterEach()` function in the declared order. This is a great way to logically group specs in any level as you see fit.
-
-```javascript
-describe("A spec", function() {
-
-     beforeEach(function( currentSpec ) {
-          coldbox = 22;
-          application.wirebox = new coldbox.system.ioc.Injector();
-     });
-
-     afterEach(function( currentSpec ) {
-          coldbox = 0;
-          structDelete( application, "wirebox" );
-     });
-
-     it("is just a function, so it can contain any code", function() {
-          expect( coldbox ).toBe( 22 );
-     });
-
-     it("can have more than one expectation and talk to scopes", function() {
-          expect( coldbox ).toBe( 22 );
-          expect( application.wirebox.getInstance( 'MyService' ) ).toBeComponent();
-     });
-
-     describe("nested inside a second describe", function() {
-
-          beforeEach(function( currentSpec ) {
-               awesome = 22;
-          });
-
-          afterEach(function( currentSpec ) {
-               awesome = 22 + 8;
-          });
-
-          it("can reference both scopes as needed ", function() {
-            expect( coldbox ).toBe( awesome );
-          });
-     });
-
-     it("can be declared after nested suites and have access to nested variables", function() {
-          expect( awesome ).toBe( 30 );
-     });
-
-});
-```
-
-## Given-When-Then Blocks
+# Given-When-Then Blocks
 
 [Given-When-Then](http://martinfowler.com/bliki/GivenWhenThen.html) is a style of writing tests where you describe the state of the code you want to test \(`Given`\), the behavior you want to test \(`When`\) and the expected outcome \(`Then`\). \(See [Specification By Example](http://martinfowler.com/bliki/SpecificationByExample.html)\)
 
@@ -134,4 +63,3 @@ story("As a distribution manager, I want to know the volume of the box I need", 
 ```
 
 As `feature()`, `scenario()` and `story()` are wrappers for `describe()` you can intermix them so that your can create tests which read as the business requirements. As with `describe()`, they can be nested to build up blocks.
-


### PR DESCRIPTION
I had a difficult time finding reference to Gherkin-style tests because it was nested inside the Suite Groups page. This pull request would move the `Given-When-Then Blocks` discussion to its own page as a subsection of Suite Groups.