### PR TITLE
Add documentation for generate harness CLI command

### DIFF
--- a/introduction/installing-testbox/README.md
+++ b/introduction/installing-testbox/README.md
@@ -24,3 +24,8 @@ You can also clone from [Github](https://github.com/ortus-solutions/testbox) and
 git clone git://github.com/ortus-solutions/testbox testbox
 ```
 
+Once you have testbox installed, you'll need a quick way to set up a testing harness. The `generate harness` command will add a new `/tests` folder to your application with a few example tests to get you started.
+
+```bash
+box testbox generate harness
+```


### PR DESCRIPTION
This is a totally undocumented feature, and honestly threw me for a long time! I used to copy the `test-harness` folder out of `testbox` into `/tests` when I first got started writing Testbox tests.