### PR TITLE
Improve the formatting for clarity

### DIFF
--- a/in-depth/running-tests/directory-runner.md
+++ b/in-depth/running-tests/directory-runner.md
@@ -4,23 +4,31 @@
 <cfset r = new coldbox.system.TestBox( directory="coldbox.testing.cases.testing.specs" ) >
 <cfoutput>#r.run()#</cfoutput>
 
-<cfset r = new coldbox.system.TestBox( directory={ mapping="coldbox.testing.cases.testing.specs", recurse=false } ) >
+<cfset r = new coldbox.system.TestBox( 
+      directory={ 
+            mapping="coldbox.testing.cases.testing.specs", 
+            recurse=false 
+      }) >
 <cfoutput>#r.run()#</cfoutput>
 
 <cfset r = new coldbox.system.TestBox(
-      directory={ mapping="coldbox.testing.cases.testing.specs",
-      recurse=true,
-      filter=function(path){
-            return ( findNoCase( "test", arguments.path ) ? true : false );
-      }}) >
+      directory={ 
+            mapping="coldbox.testing.cases.testing.specs",
+            recurse=true,
+            filter=function(path){
+                  return ( findNoCase( "test", arguments.path ) ? true : false );
+            }
+      }) >
 <cfoutput>#r.run()#</cfoutput>
 
 <cfset r = new coldbox.system.TestBox(
-      directory={ mapping="coldbox.testing.cases.testing.specs",
-      recurse=true,
-      filter=function(path){
-            return ( findNoCase( "test", arguments.path ) ? true : false );
-      }}) >
+      directory={ 
+            mapping="coldbox.testing.cases.testing.specs",
+            recurse=true,
+            filter=function(path){
+                  return ( findNoCase( "test", arguments.path ) ? true : false );
+            }
+      }) >
 <cfset fileWrite( 'testreports.json', r.run() )>
 ```
 


### PR DESCRIPTION
Improve the formatting to make it clearer that the directory argument is a struct