### PR TITLE
Correct malformed markdown

### DIFF
--- a/primers/testbox-bdd-primer/running-tests.md
+++ b/primers/testbox-bdd-primer/running-tests.md
@@ -98,7 +98,13 @@ In our test samples and templates we include an ANT runner that will be able to 
 
 ### Test Runner
 
-If you make your test bundle CFC inherit from our testbox.system.BaseSpec class, you will be able to execute the CFC directly via the URL: \`\`\`javascript [http://localhost/test/MyTest.cfc?method=runRemote](http://localhost/test/MyTest.cfc?method=runRemote) \`\`\` You can also pass the following arguments to the method via the URL: \* \*\*testSuites\*\* : A list or array of suite names that are the ones that will be executed ONLY! \* \*\*testSpecs\*\* : A list or array of test names that are the ones that will be executed ONLY! \* \*\*reporter\*\* : The type of reporter to run the test with \`\`\`javascript [http://localhost/test/MyTest.cfc?method=runRemote&reporter=json](http://localhost/test/MyTest.cfc?method=runRemote&reporter=json) \`\`\`
+If you make your test bundle CFC inherit from our `testbox.system.BaseSpec` class, you will be able to execute the CFC directly via the URL: [http://localhost/test/MyTest.cfc?method=runRemote](http://localhost/test/MyTest.cfc?method=runRemote).
+
+You can also pass the following arguments to the method via the URL:
+
+- `testSuites`: A list or array of suite names that are the ones that will be executed ONLY!
+- `testSpecs`: A list or array of test names that are the ones that will be executed ONLY!
+- `reporter`: The type of reporter to run the test with [http://localhost/test/MyTest.cfc?method=runRemote&reporter=json](http://localhost/test/MyTest.cfc?method=runRemote&reporter=json)
 
 ### Directory Runner
 

--- a/primers/testbox-xunit-primer/running-tests.md
+++ b/primers/testbox-xunit-primer/running-tests.md
@@ -89,7 +89,13 @@ In our test samples and templates we include an ANT runner that will be able to 
 
 ### Test Runner
 
-If you make your test bundle CFC inherit from our testbox.system.BaseSpec class, you will be able to execute the CFC directly via the URL: \`\`\`javascript [http://localhost/test/MyTest.cfc?method=runRemote](http://localhost/test/MyTest.cfc?method=runRemote) \`\`\` You can also pass the following arguments to the method via the URL: \* \*\*testSuites\*\* : A list or array of suite names that are the ones that will be executed ONLY! \* \*\*testSpecs\*\* : A list or array of test names that are the ones that will be executed ONLY! \* \*\*reporter\*\* : The type of reporter to run the test with \`\`\`javascript [http://localhost/test/MyTest.cfc?method=runRemote&reporter=json](http://localhost/test/MyTest.cfc?method=runRemote&reporter=json) \`\`\`
+If you make your test bundle CFC inherit from our `testbox.system.BaseSpec` class, you will be able to execute the CFC directly via the URL: [http://localhost/test/MyTest.cfc?method=runRemote](http://localhost/test/MyTest.cfc?method=runRemote).
+
+You can also pass the following arguments to the method via the URL:
+
+- `testSuites`: A list or array of suite names that are the ones that will be executed ONLY!
+- `testSpecs`: A list or array of test names that are the ones that will be executed ONLY!
+- `reporter`: The type of reporter to run the test with [http://localhost/test/MyTest.cfc?method=runRemote&reporter=json](http://localhost/test/MyTest.cfc?method=runRemote&reporter=json)
 
 ### Directory Runner
 


### PR DESCRIPTION
Correct some malformed markdown on what URL query params can be provided to the test runner that was preventing text from rendering correctly.