### PR TITLE
Clarify example to add generationPath

### DIFF
--- a/mocking/mockbox/creating-mockbox.md
+++ b/mocking/mockbox/creating-mockbox.md
@@ -1,10 +1,10 @@
 # Creating MockBox
 
 ```javascript
-mockBox = new testbox.system.MockBox();
+mockBox = new testbox.system.MockBox( [generationPath] );
 
 // Within a TestBox Spec
-getMockBox()
+getMockBox( [generationPath] )
 ```
 
 The factory takes in one constructor argument that is not mandatory: `generationPath`. This path is a relative path of where the factory generates internal mocking stubs that are included later on at runtime. Therefore, the path must be a path that can be used using `cfinclude`. The default path the mock factory uses is the following, so you do not have to specify one, just make sure the path has WRITE permissions:


### PR DESCRIPTION
Added generationPath to example 

This matches other examples
* https://testbox.ortusbooks.com/primers/testbox-xunit-primer/spies-and-mocking
* https://testbox.ortusbooks.com/in-depth/test-bundles/injected-methods