### PR TITLE
Update global-runner.md

### DIFF
--- a/getting-started/running-tests/global-runner.md
+++ b/getting-started/running-tests/global-runner.md
@@ -6,8 +6,8 @@ icon: g
 
 TestBox ships with a global runner that can be used to run pretty much anything. You can customize it or place it wherever you need it.  You can find it in your distribution under:
 
-* BoxLang: `/testbox/bx/test-browser`
-* CFML: `/testbox/cfml/test-browser`
+* BoxLang: `/testbox/bx/browser`
+* CFML: `/testbox/cfml/browser`
 
 This is a mini web application to help you run bundles, directory, specs and more.
 


### PR DESCRIPTION
As of v6.0.1+9 the directory is called `/testbox/bx/browser/` not `/testbox/bx/test-browser/` and  `/testbox/cfml/browser/` not `/testbox/cfml/test-browser/`