### PR TITLE
Update test-browser.md

### DIFF
--- a/getting-started/running-tests/test-browser.md
+++ b/getting-started/running-tests/test-browser.md
@@ -6,8 +6,8 @@ icon: window
 
 TestBox ships with a test browser that is highly configurable to whatever URL accessible path you want. It will then show you a test browser where you can navigate and execute not only individual tests, but also directory suites as well.
 
-* BoxLang: `/testbox/bx/test-browser`
-* CFML: `/testbox/cfml/test-browser`
+* BoxLang: `/testbox/bx/browser`
+* CFML: `/testbox/cfml/browser`
 
 It is also a mini web application that can be configured to whatever root folder you desire.  It will read the runners and tests from that folder and present a GUI that you can use to navigate the test folders and execute them easily.
 


### PR DESCRIPTION
As of v6.0.1+9 the directory is called `/testbox/bx/browser/` not `/testbox/bx/test-browser/` and  `/testbox/cfml/browser/` not `/testbox/cfml/test-browser/`